### PR TITLE
Fix for cut off "X" close img, if using lightbox with bootstrap.

### DIFF
--- a/themes/default/default.css
+++ b/themes/default/default.css
@@ -10,7 +10,7 @@
 .nivo-lightbox-theme-default * {
 	-webkit-box-sizing: initial !important;
 	-moz-box-sizing: initial !important;
-	box-sizing: initial !important;
+	box-sizing: content-box !important;
 }
  
 .nivo-lightbox-theme-default.nivo-lightbox-overlay { 

--- a/themes/default/default.css
+++ b/themes/default/default.css
@@ -6,6 +6,12 @@
  * Free to use and abuse under the MIT license.
  * http://www.opensource.org/licenses/mit-license.php
  */
+
+.nivo-lightbox-theme-default * {
+	-webkit-box-sizing: initial !important;
+	-moz-box-sizing: initial !important;
+	box-sizing: initial !important;
+}
  
 .nivo-lightbox-theme-default.nivo-lightbox-overlay { 
 	background: #666;


### PR DESCRIPTION
If using bootstrap, a global `box-sizing` attribute causes a small issue with the close image button, using the default nivo lightbox theme.