### PR TITLE
Fixed video embeds for HTTPS

### DIFF
--- a/nivo-lightbox.js
+++ b/nivo-lightbox.js
@@ -194,15 +194,15 @@
                     classTerm = 'nivo-lightbox-video';
 
                 if(video[1] == 'youtube'){
-                    src = 'http://www.youtube.com/embed/'+ video[4];
+                    src = '//www.youtube.com/embed/'+ video[4];
                     classTerm = 'nivo-lightbox-youtube';
                 }
                 if(video[1] == 'youtu'){
-                    src = 'http://www.youtube.com/embed/'+ video[3];
+                    src = '//www.youtube.com/embed/'+ video[3];
                     classTerm = 'nivo-lightbox-youtube';
                 }
                 if(video[1] == 'vimeo'){
-                    src = 'http://player.vimeo.com/video/'+ video[3];
+                    src = '//player.vimeo.com/video/'+ video[3];
                     classTerm = 'nivo-lightbox-vimeo';
                 }
 


### PR DESCRIPTION
This fixes an issue where attempting to load a youtube / vimeo video on a page loaded via HTTPS fails to display due to being force-loaded via HTTP. This makes the default base embed links protocol-relative to the page it is loaded on.