### PR TITLE
Add meta tags required for installing via NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   },
   "license": "MIT",
   "author": "Gilbert Pellegrom <gilbert@pellegrom.me>",
+  "version": "1.3.1",
+  "main": "./nivo-lightbox.js",
+  "style": "./nivo-lightbox.css",
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-clean-css": "^2.0.13",


### PR DESCRIPTION
Allow folks to install this package using `npm install`.
This replaces #70 (has a typo) and #71 (missing a comma).